### PR TITLE
Bugfix facade accessor

### DIFF
--- a/src/Facade.php
+++ b/src/Facade.php
@@ -2,6 +2,8 @@
 
 namespace Maknz\Slack\Laravel;
 
+use Maknz\Slack\Client as Client;
+
 class Facade extends \Illuminate\Support\Facades\Facade
 {
     /**
@@ -11,6 +13,6 @@ class Facade extends \Illuminate\Support\Facades\Facade
      */
     protected static function getFacadeAccessor()
     {
-        return 'maknz.slack';
+        return Client::class;
     }
 }


### PR DESCRIPTION
Facade was not working on Laravel 5.x due to changed accessor.